### PR TITLE
extend framework to support inverse regex matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ tests:
         notPresent:              # Specify headers not expected to exist.
           - 'set-cookie'         # These are not regular expressions
           - 'x-frame-options'
+        notMatching:
+          set-cookie: ^.*abc.*$  # Specify headers expected to exist but NOT match the given regex
       body:                      # Response body
         patterns:                # Response body has to match all patterns in this list in order to pass test
           - 'charset="utf-8"'    # Regular expressions

--- a/parser.go
+++ b/parser.go
@@ -51,6 +51,7 @@ type Test struct {
 		Headers     struct {
 			Patterns   map[string]string `yaml:"patterns"`
 			NotPresent []string          `yaml:"notPresent"`
+			NotMatching map[string]string `yaml:"notMatching"`
 		} `yaml:"headers"`
 		Body struct {
 			Patterns []string `yaml:"patterns"`


### PR DESCRIPTION
Go does not support lookarounds in regular expressions. In order to do inverse regex matching on HTTP headers (i.e. asserting that a header does NOT match a certain pattern), the "NotMatching" element can be used in the YAML.