### PR TITLE
bump up timeout value since we are seeing Client.Timeout exceeded whi…

### DIFF
--- a/http.go
+++ b/http.go
@@ -57,7 +57,7 @@ func SendHTTPRequest(config *HTTPRequestConfig) (*http.Response, []byte, error) 
 	}
 
 	if config.TimeoutSeconds == 0 {
-		config.TimeoutSeconds = 5
+		config.TimeoutSeconds = 10
 	}
 
 	// Create request


### PR DESCRIPTION
we have one occurrence of the following error message: 
```
net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```
It appears, the  net/http Client.go does not set default timeout duration, httptest does set it to 5 sec, this PR bump it up to 10 sec. 

Research of this error suggest this mostly like a transient and sporadic issue, mostly happens at TLS library handshake, so first tune up our setting on timeout. 