### PR TITLE
Comment on actions only config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,6 +11,13 @@ categories:
     label: 'docs'
   - title: 'Other'
     label: 'other'
+template: |
+  # Changelog
+  
+  $CHANGES
+
+  Changes since previous release: https://github.com/nytimes/httptest/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION
+# BELOW: actions only configuration not in use
 version-resolver:
   major:
     labels:
@@ -19,9 +26,3 @@ version-resolver:
     labels:
       - 'new feature'
   default: patch
-template: |
-  # Changelog
-  
-  $CHANGES
-
-  Changes since previous release: https://github.com/nytimes/httptest/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION


### PR DESCRIPTION
That config is not available in the apps version of release drafter: https://probot.github.io/apps/release-drafter/