### PR TITLE
Add two additional valid http methods: HEAD and OPTIONS

### DIFF
--- a/tester.go
+++ b/tester.go
@@ -98,8 +98,8 @@ func preProcessTest(test *Test, defaultHost string) error {
 
 	// Method
 	method := stringValue(test.Request.Method, "GET")
-	if method != "GET" && method != "POST" && method != "PUT" && method != "PATCH" && method != "DELETE" {
-		return fmt.Errorf("invalid method %s. only GET, POST, PUT, PATCH, DELETE are supported", method)
+	if method != "GET" && method != "POST" && method != "PUT" && method != "PATCH" && method != "DELETE" && method != "HEAD" && method != "OPTIONS" {
+		return fmt.Errorf("invalid method %s. only GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS are supported", method)
 	}
 	test.Request.Method = method
 


### PR DESCRIPTION
Hoping to use this to test an OPTIONS request, and noticed both of these methods were excluded during validation. I tested it locally and the http library doesn't seem to have any trouble handling them.