### PR TITLE
DV-18667-Adds functionality for testing not present subfields

### DIFF
--- a/example-tests/httpbin.yml
+++ b/example-tests/httpbin.yml
@@ -23,6 +23,24 @@ tests:
         patterns:
           - 'https://httpbin.org/get'
 
+  - description: 'HTTPS GET'
+    request:
+      path: '/get'
+    response:
+      statusCodes: [200]
+      headers:
+        patterns:
+          access-control-allow-origin: '.+'
+        notPresent:
+          - 'not-present-header'
+        notMatching:
+          access-control-allow-origin: 'example.com'
+        notPresentSubfields:
+          Content-Type: 'notreal/fake'
+      body:
+        patterns:
+          - 'https://httpbin.org/get'
+
   - description: 'HTTP POST'
     request:
       method: 'POST'

--- a/parser.go
+++ b/parser.go
@@ -50,9 +50,10 @@ type Test struct {
 	Response struct {
 		StatusCodes []int `yaml:"statusCodes"`
 		Headers     struct {
-			Patterns    map[string]string `yaml:"patterns"`
-			NotPresent  []string          `yaml:"notPresent"`
-			NotMatching map[string]string `yaml:"notMatching"`
+			Patterns            map[string]string `yaml:"patterns"`
+			NotPresent          []string          `yaml:"notPresent"`
+			NotMatching         map[string]string `yaml:"notMatching"`
+			NotPresentSubfields map[string]string `yaml:"notPresentSubfields"`
 		} `yaml:"headers"`
 		Body struct {
 			Patterns []string `yaml:"patterns"`

--- a/tester.go
+++ b/tester.go
@@ -209,6 +209,14 @@ func validateResponseHeaders(test *Test, response *http.Response) []error {
 		}
 	}
 
+	npSubfieldAssertions := expectedResponse.Headers.NotPresentSubfields
+	for header := range npSubfieldAssertions {
+		respHeaderValue := response.Header.Get(header)
+		if len(respHeaderValue) > 0 {
+			errors = append(errors, validateResponseHeaderPatterns(response, expectedResponse.Headers.NotPresentSubfields, false)...)
+		}
+	}
+
 	return errors
 }
 

--- a/utils.go
+++ b/utils.go
@@ -26,9 +26,7 @@ func AppendHostsFile(content string) error {
 		return err
 	}
 
-	fmt.Printf(fmt.Sprintf("\n%s\n", content))
-
-	if _, err := f.Write([]byte(fmt.Sprintf("\n%s\n", content))); err != nil {
+t	if _, err := f.Write([]byte(fmt.Sprintf("\n%s\n", content))); err != nil {
 		return err
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -26,7 +26,9 @@ func AppendHostsFile(content string) error {
 		return err
 	}
 
-t	if _, err := f.Write([]byte(fmt.Sprintf("\n%s\n", content))); err != nil {
+	fmt.Printf(fmt.Sprintf("\n%s\n", content))
+
+	if _, err := f.Write([]byte(fmt.Sprintf("\n%s\n", content))); err != nil {
 		return err
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -26,8 +26,6 @@ func AppendHostsFile(content string) error {
 		return err
 	}
 
-	fmt.Printf(fmt.Sprintf("\n%s\n", content))
-
 	if _, err := f.Write([]byte(fmt.Sprintf("\n%s\n", content))); err != nil {
 		return err
 	}

--- a/utils.go
+++ b/utils.go
@@ -26,6 +26,8 @@ func AppendHostsFile(content string) error {
 		return err
 	}
 
+	fmt.Printf(fmt.Sprintf("\n%s\n", content))
+
 	if _, err := f.Write([]byte(fmt.Sprintf("\n%s\n", content))); err != nil {
 		return err
 	}


### PR DESCRIPTION
As part of [DV-18667](https://jira.nyt.net/browse/DV-18667), we are moving groups of headers in fastly to header maps (aka concatenated headers or header subfields). This PR adds a new test assertion for checking if a header subfield is not present. 

This is tested via a combination of testing to see if the header map exists at all and, if it does, checking the header's string value to confirm that the provided pattern is not present in the string.

A new GET test was added in the example-tests/httbin.yaml file to test this new assertion.