### PR TITLE
Adds IfPresentNotMatching assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ tests:
     response:
       headers:
         notMatching: 
-          Server: ^(.*(nginx|42)).* # If Server does not match either portion of the pattern (nginx or 42) the test passes, else it fails
+          Server: ^(.*(nginx|42)).*            # If Server does not match either portion of the pattern (nginx or 42) the test passes, else it fails
       statusCodes:
         - 200
 ```

--- a/README.md
+++ b/README.md
@@ -316,6 +316,31 @@ tests:
       path: '/signup'
     response:
       statusCodes: [200]
+
+  - description: 'HTTPS GET - test if present not matching'
+    request:
+      path: '/get'
+    conditions:
+      env:
+        TEST_ENV: dev
+    response:
+      statusCodes: [200]
+      headers:
+        ifPresentNotMatching:
+          Content-Type: ^notreal/fake$ # If Content-Type does not match this pattern the test passes, else it fails
+
+  - description: 'HTTPS GET - test if present not matching multiple possible matches'
+    request:
+      path: /get
+    conditions:
+      env:
+        TEST_ENV: dev
+    response:
+      headers:
+        notMatching: 
+          Server: ^(.*(nginx|42)).* # If Server does not match either portio of the pattern (nginx or 42) the test passes, else it fails
+      statusCodes:
+        - 200
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ tests:
       statusCodes: [200]
       headers:
         ifPresentNotMatching:
-          Content-Type: ^notreal/fake$ # If Content-Type does not match this pattern the test passes, else it fails
+          Content-Type: ^notreal/fake$         # If Content-Type does not exist or does not match this pattern the test passes, else it fails
 
   - description: 'HTTPS GET - test if present not matching multiple possible matches'
     request:

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ tests:
     response:
       headers:
         notMatching: 
-          Server: ^(.*(nginx|42)).* # If Server does not match either portio of the pattern (nginx or 42) the test passes, else it fails
+          Server: ^(.*(nginx|42)).* # If Server does not match either portion of the pattern (nginx or 42) the test passes, else it fails
       statusCodes:
         - 200
 ```

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ tests:
 
   - description: 'HTTPS GET - test if present not matching multiple possible matches'
     request:
-      path: /get
+      path: '/get'
     conditions:
       env:
         TEST_ENV: dev

--- a/example-tests/httpbin.yml
+++ b/example-tests/httpbin.yml
@@ -34,9 +34,6 @@ tests:
       headers:
         ifPresentNotMatching:
           Content-Type: ^notreal/fake$
-      body:
-        patterns:
-          - 'https://httpbin.org/get'
 
   - description: 'HTTPS GET - if present not matching multiple possible matches'
     request:

--- a/example-tests/httpbin.yml
+++ b/example-tests/httpbin.yml
@@ -23,6 +23,37 @@ tests:
         patterns:
           - 'https://httpbin.org/get'
 
+  - description: 'HTTPS GET - if present not matching'
+    request:
+      path: '/get'
+    conditions:
+      env:
+        TEST_ENV: dev
+    response:
+      statusCodes: [200]
+      headers:
+        ifPresentNotMatching:
+          Content-Type: ^notreal/fake$
+      body:
+        patterns:
+          - 'https://httpbin.org/get'
+
+  - description: 'HTTPS GET - if present not matching multiple possible matches'
+    request:
+      path: /get
+    conditions:
+      env:
+        TEST_ENV: dev
+    response:
+      headers:
+        notMatching: 
+          Server: ^(.*(nginx|42)).*
+      statusCodes:
+        - 200
+      body:
+        patterns:
+          - 'https://httpbin.org/get'
+
   - description: 'HTTP POST'
     request:
       method: 'POST'

--- a/example-tests/httpbin.yml
+++ b/example-tests/httpbin.yml
@@ -40,7 +40,7 @@ tests:
 
   - description: 'HTTPS GET - if present not matching multiple possible matches'
     request:
-      path: /get
+      path: '/get'
     conditions:
       env:
         TEST_ENV: dev

--- a/parser.go
+++ b/parser.go
@@ -50,9 +50,10 @@ type Test struct {
 	Response struct {
 		StatusCodes []int `yaml:"statusCodes"`
 		Headers     struct {
-			Patterns    map[string]string `yaml:"patterns"`
-			NotPresent  []string          `yaml:"notPresent"`
-			NotMatching map[string]string `yaml:"notMatching"`
+			Patterns             map[string]string `yaml:"patterns"`
+			NotPresent           []string          `yaml:"notPresent"`
+			NotMatching          map[string]string `yaml:"notMatching"`
+			IfPresentNotMatching map[string]string `yaml:"ifPresentNotMatching"`
 		} `yaml:"headers"`
 		Body struct {
 			Patterns []string `yaml:"patterns"`

--- a/tester.go
+++ b/tester.go
@@ -216,7 +216,7 @@ func validateResponseHeaders(test *Test, response *http.Response) []error {
 	ipnmHeaders := expectedResponse.Headers.IfPresentNotMatching
 	for header := range ipnmHeaders {
 		if len(response.Header.Get(header)) > 0 {
-			errors = append(errors, validateResponseHeaderPatterns(response, ipnmHeaders, false, expectFailure)...)
+			errors = append(errors, validateResponseHeaderPatterns(response, ipnmHeaders, false)...)
 		}
 	}
 

--- a/tester.go
+++ b/tester.go
@@ -211,14 +211,12 @@ func validateResponseHeaders(test *Test, response *http.Response) []error {
 
 	// IfPresentNotMatching assertions come in the form of key/value pairs where the key is the header name and the value is
 	// the pattern that we want to confirm does not exist within that header. Here we test that in two steps:
-	//		1. Check if the header, itself exists. If it does not the test automatically passes.
-	//		2. If the header does exist we pass the full list of IfPresentNotMatching key/value pairs to the validate function
-	//			which errors if the pattern is matched in the header.
-	ifPresentNotMatchingAssertions := expectedResponse.Headers.IfPresentNotMatching
-	for header := range ifPresentNotMatchingAssertions {
-		respHeaderValue := response.Header.Get(header)
-		if len(respHeaderValue) > 0 {
-			errors = append(errors, validateResponseHeaderPatterns(response, expectedResponse.Headers.IfPresentNotMatching, false)...)
+	//		1. If the header doesn't exists, the test automatically passes.
+	//		2. If the header does exist, validate against the not matching assertions.
+	ipnmHeaders := expectedResponse.Headers.IfPresentNotMatching
+	for header := range ipnmHeaders {
+		if len(response.Header.Get(header)) > 0 {
+			errors = append(errors, validateResponseHeaderPatterns(response, ipnmHeaders, false, expectFailure)...)
 		}
 	}
 


### PR DESCRIPTION
Adds a test assertion for testing if a header does exist that it does not match a regex pattern provided.

This is split off from https://github.com/nytimes/httptest/pull/43 to allow us to merge this functionality first and addressing the `shouldFail` portion later on.