### PR TITLE
Fix retry panic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ httptest
 
 # macOS
 .DS_Store
+
+*.vscode/

--- a/internal/config.go
+++ b/internal/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package internal
 
 import (
 	"fmt"

--- a/internal/config.go
+++ b/internal/config.go
@@ -56,9 +56,9 @@ func FromEnv() (*Config, error) {
 		printFailedOnly = true
 	}
 
-	enableRetries := true
-	if getEnv("ENABLE_RETRIES", "true") == "false" {
-		enableRetries = false
+	enableRetries := false
+	if getEnv("ENABLE_RETRIES", "false") == "true" {
+		enableRetries = true
 	}
 
 	retryCount, err := strconv.Atoi(getEnv("DEFAULT_RETRY_COUNT", "2"))

--- a/internal/coordinator.go
+++ b/internal/coordinator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package internal
 
 import (
 	"sync"

--- a/internal/dynamic.go
+++ b/internal/dynamic.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package internal
 
 import (
 	"fmt"

--- a/internal/http.go
+++ b/internal/http.go
@@ -112,6 +112,7 @@ func SendHTTPRequest(config *HTTPRequestConfig) (*http.Response, []byte, error) 
 	if config.MaxRetries > 0 {
 		client.RetryMax = config.MaxRetries
 		client.CheckRetry = config.RetryCallback
+		client.Backoff = retryablehttp.DefaultBackoff
 	} else {
 		// Don't retry requests
 		client.CheckRetry = func(ctx context.Context, resp *http.Response, inErr error) (bool, error) { return false, nil }

--- a/internal/http.go
+++ b/internal/http.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package internal
 
 import (
 	"bytes"

--- a/internal/output.go
+++ b/internal/output.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package internal
 
 import (
 	"fmt"

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package internal
 
 import (
 	"fmt"

--- a/internal/tester.go
+++ b/internal/tester.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package internal
 
 import (
 	"context"

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package internal
 
 import (
 	"fmt"

--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	ht "github.com/nytimes/httptest/internal"
 )
 
 var (
@@ -78,12 +80,12 @@ func main() {
 	fmt.Printf("httptest: %s %s %s\n", BuildCommit, BuildBranch, BuildTime)
 
 	// Get and apply config
-	config, err := FromEnv()
+	config, err := ht.FromEnv()
 	if err != nil {
 		log.Fatalf("error: failed to parse config: %s", err)
 	}
 
-	if err := ApplyConfig(config); err != nil {
+	if err := ht.ApplyConfig(config); err != nil {
 		log.Fatalf("error: failed to apply config: %s", err)
 	}
 
@@ -92,12 +94,12 @@ func main() {
 	zap.ReplaceGlobals(logger)
 
 	// Parse and run tests
-	tests, err := ParseAllTestsInDirectory(config.TestDirectory)
+	tests, err := ht.ParseAllTestsInDirectory(config.TestDirectory)
 	if err != nil {
 		log.Fatalf("error: failed to parse tests: %s", err)
 	}
 
-	if !RunTests(tests, config) {
+	if !ht.RunTests(tests, config) {
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Previously, a panic was happening whenever a request was getting re-tried  since no default backoff policy was being set for retries. 

This pr:
* sets the default backoff policy
* consolidates code mostly into the `internal` package
* disables retries by default