### PR TITLE
Add retries for failed tests

### DIFF
--- a/internal/output.go
+++ b/internal/output.go
@@ -29,7 +29,13 @@ func PrintTestResult(test *Test, result *TestResult) {
 	if result.Skipped {
 		color.HiBlue("SKIPPED")
 	} else if len(result.Errors) < 1 {
-		color.HiGreen("PASSED")
+		var output string
+		if result.Retries > 0 {
+			output = fmt.Sprintf("PASSED (RETRIES: %d)", result.Retries)
+		} else {
+			output = "PASSED"
+		}
+		color.HiGreen(output)
 	} else {
 		color.HiRed("FAILED")
 	}


### PR DESCRIPTION
Was working on [this ticket](https://nytimes.atlassian.net/jira/software/c/projects/DV/issues/DV-21952?filter=myopenissues&jql=project%20%3D%20%22DV%22%20AND%20assignee%20IN%20%28currentUser%28%29%29%20AND%20statusCategory%20IN%20%28%22To%20Do%22%2C%20%22In%20Progress%22%29%20ORDER%20BY%20created%20DESC) which involves a flake from one of our vendors that we do not have direct control over. The HTTP request succeeds but the data that comes back is incorrect. It only happens ~0.1% of the time, but when we run 180 of these tests in CI it leads to annoying flakes. Due to the pipeline pain these tests ended up being ignored/commented out and we ended up missing a real issue that would have been caught by the tests.

I wanted a way to retry failed tests automatically without having to restart the pipeline. I know this is a spicy topic as far as CI is concerned (drone explicitly does not have a method of retrying failed pipeline steps), but open to opinions. Tested this implementation of retries on the flake I was experiencing. 

![image](https://github.com/user-attachments/assets/370d172c-a461-4085-9a44-87b5376b1447)

This implementation re-uses the existing DEFAULT_RETRY_COUNT environment variable that is used to control HTTP request retries. I did not want to introduce any breaking changes (changing env var name), and felt that a new env var along the lines of RETRY_FAILED_TESTS_COUNT was a little confusing. If anyone thinks of a nice naming scheme I'm happy to add it instead of re-using the existing env var.
