### PR TITLE
Switch back to Alpine, improve commit_sha and branch vars

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -52,6 +52,12 @@ jobs:
               }
             }
 
+      - name: Set the commit_sha and branch
+        shell: bash
+        run: |
+          echo "commit_sha=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
+          echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> "$GITHUB_ENV"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -52,6 +52,12 @@ jobs:
               }
             }
 
+      - name: Set the commit_sha and branch
+        shell: bash
+        run: |
+          echo "commit_sha=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
+          echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> "$GITHUB_ENV"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -20,6 +20,12 @@ jobs:
               }
             }
 
+      - name: Set the commit_sha and branch
+        shell: bash
+        run: |
+          echo "commit_sha=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
+          echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> "$GITHUB_ENV"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ ARG DRONE_COMMIT
 # Build application
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o /go/bin/httptest \
   -ldflags "-extldflags \"-static\" \
-  -X main.BuildBranch=${env.branch} \
-  -X main.BuildCommit=${env.commit_sha} \
   -X main.BuildTime=$(date -Iseconds)"
 
 # We can't use distroless because some teams need to add a bearer token to

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ ARG DRONE_COMMIT
 # Build application
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o /go/bin/httptest \
   -ldflags "-extldflags \"-static\" \
-  -X main.BuildBranch=${{ env.branch }} \
-  -X main.BuildCommit=${{ env.commit_sha }} \
+  -X main.BuildBranch=${ env.branch } \
+  -X main.BuildCommit=${ env.commit_sha } \
   -X main.BuildTime=$(date -Iseconds)"
 
 # We can't use distroless because some teams need to add a bearer token to

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ ARG DRONE_COMMIT
 # Build application
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o /go/bin/httptest \
   -ldflags "-extldflags \"-static\" \
-  -X main.BuildBranch=${ env.branch } \
-  -X main.BuildCommit=${ env.commit_sha } \
+  -X main.BuildBranch=${env.branch} \
+  -X main.BuildCommit=${env.commit_sha} \
   -X main.BuildTime=$(date -Iseconds)"
 
 # We can't use distroless because some teams need to add a bearer token to

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,16 @@ ARG DRONE_COMMIT
 # Build application
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o /go/bin/httptest \
   -ldflags "-extldflags \"-static\" \
-  -X main.BuildBranch=${DRONE_BRANCH} \
-  -X main.BuildCommit=${DRONE_COMMIT:0:8} \
+  -X main.BuildBranch=${{ env.branch }} \
+  -X main.BuildCommit=${{ env.commit_sha }} \
   -X main.BuildTime=$(date -Iseconds)"
 
-# Distroless; smaller than Alpine, has SSL included, works for multi-arch
-FROM gcr.io/distroless/static-debian12
+# We can't use distroless because some teams need to add a bearer token to
+# authenticate when the tests are run
+FROM alpine
+
+# Install dependencies
+RUN apk add --no-cache ca-certificates
 
 # Copy binary from build container
 COPY --from=build /go/bin/httptest /bin/httptest


### PR DESCRIPTION
It turns out that some folks need the `httptest` Docker image to have a shell so that they can set bearer tokens. This PR switches back to Alpine and also fixes the variables that we're setting on the builds now that we've moved away from Drone.